### PR TITLE
Hardcode term 13 NPM start dates

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -7,8 +7,8 @@ require 'pry'
 require 'scraperwiki'
 require 'scraped_page_archive/open-uri'
 
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
+# require 'open-uri/cached'
+# OpenURI::Cache.cache_path = '.cache'
 
 class String
   def tidy

--- a/scraper.rb
+++ b/scraper.rb
@@ -64,7 +64,30 @@ def scrape_term(url)
     }
     data[:image] = URI.join(url, data[:image]).to_s unless data[:image].to_s.empty?
     data[:end_date] = date_from(data[:notes]) if data[:notes].to_s.include? 'Resigned on '
+    data[:end_date] ||= term[:end_date]
     data[:start_date] = date_from(data[:notes]) if data[:notes].to_s.include? 'NMP term effective '
+    data[:start_date] ||= term[:start_date]
+
+    # The start dates of NPMs are removed after the MP takes their seat.
+    # That is, we once had these start dates but now we haven't.
+    # Since the official source no longer publishes these dates,
+    # we're hardcoding them into the scraper.
+
+    ids_of_term_13_nmps = [
+      'azmoon-bin-ahmad-13',
+      'ganesh-rajaram-13',
+      'k-thanaletchimi-13',
+      'mahdev-mohan-13',
+      'randolph-tan-12',
+      'kuik-shiao-yin-12',
+      'chia-yong-yong-12',
+      'kok-heng-leun-13'
+    ]
+
+    if data[:term] == '13' && ids_of_term_13_nmps.include?(data[:id])
+      data[:start_date] = date_from('22 March 2016')
+    end
+
     ScraperWiki.save_sqlite([:id, :term], data)
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -70,20 +70,10 @@ def scrape_term(url)
     # That is, we once had these start dates but now we haven't.
     # Since the official source no longer publishes these dates,
     # we're hardcoding them into the scraper.
-
-    ids_of_term_13_nmps = [
-      'azmoon-bin-ahmad-13',
-      'ganesh-rajaram-13',
-      'k-thanaletchimi-13',
-      'mahdev-mohan-13',
-      'randolph-tan-12',
-      'kuik-shiao-yin-12',
-      'chia-yong-yong-12',
-      'kok-heng-leun-13'
-    ]
-
-    if data[:term] == '13' && ids_of_term_13_nmps.include?(data[:id])
-      data[:start_date] = date_from('22 March 2016')
+    term_13_nmps = %w(azmoon-bin-ahmad-13 ganesh-rajaram-13 k-thanaletchimi-13 
+      mahdev-mohan-13 randolph-tan-12 kuik-shiao-yin-12 chia-yong-yong-12 kok-heng-leun-13)
+    if term[:id] == '13' && term_13_nmps.include?(data[:id])
+      data[:start_date] = '2016-03-22' 
     end
 
     ScraperWiki.save_sqlite([:id, :term], data)

--- a/scraper.rb
+++ b/scraper.rb
@@ -73,7 +73,8 @@ def scrape_term(url)
     term_13_nmps = %w(azmoon-bin-ahmad-13 ganesh-rajaram-13 k-thanaletchimi-13 
       mahdev-mohan-13 randolph-tan-12 kuik-shiao-yin-12 chia-yong-yong-12 kok-heng-leun-13)
     if term[:id] == '13' && term_13_nmps.include?(data[:id])
-      data[:start_date] = '2016-03-22' 
+      data[:start_date] = '2016-03-22'
+      data[:party] = 'Nominated Member of Parliament' if data[:party].to_s.empty?
     end
 
     ScraperWiki.save_sqlite([:id, :term], data)

--- a/scraper.rb
+++ b/scraper.rb
@@ -64,9 +64,7 @@ def scrape_term(url)
     }
     data[:image] = URI.join(url, data[:image]).to_s unless data[:image].to_s.empty?
     data[:end_date] = date_from(data[:notes]) if data[:notes].to_s.include? 'Resigned on '
-    data[:end_date] ||= term[:end_date]
     data[:start_date] = date_from(data[:notes]) if data[:notes].to_s.include? 'NMP term effective '
-    data[:start_date] ||= term[:start_date]
 
     # The start dates of NPMs are removed after the MP takes their seat.
     # That is, we once had these start dates but now we haven't.


### PR DESCRIPTION
   The start dates of NPMs are removed after the takes their seat.
    That is, we once had these start dates but now we haven't.
    Since the official source no longer publishes these dates,
    we're hardcoding them into the scraper.

Closes https://github.com/everypolitician/everypolitician-data/issues/14081
